### PR TITLE
- Fixed /showincludes include parsing. Relative includes were ignored…

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -729,6 +729,12 @@ bool ObjectNode::ProcessIncludesMSCL( const char * output, uint32_t outputSize )
     Timer t;
 
     {
+        if (CIncludeParser::DetectMS_ShowIncludesMarker( GetCompiler()->GetExecutable() ) == false )
+        {
+            FLOG_ERROR("Unable to detect /showincludes marker for current language");
+            return false;
+        }
+
         CIncludeParser parser;
         bool result = ( output && outputSize ) ? parser.ParseMSCL_Output( output, outputSize )
                                                : false;

--- a/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.h
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.h
@@ -7,6 +7,8 @@
 //------------------------------------------------------------------------------
 #include "Core/Containers/Array.h"
 #include "Core/Strings/AString.h"
+#include "Core/Strings/AStackString.h"
+#include "Core/Process/Mutex.h"
 
 // CIncludeParser class
 //------------------------------------------------------------------------------
@@ -28,6 +30,8 @@ public:
         inline size_t GetNonUniqueCount() const { return m_NonUniqueCount; }
     #endif
 
+    static bool DetectMS_ShowIncludesMarker( const AString & compiler );
+
 private:
     static void ParseToNextLineStartingWithHash( const char * & pos );
 
@@ -44,6 +48,10 @@ private:
     #ifdef DEBUG
         size_t m_NonUniqueCount;    // number of include directives seen
     #endif
+
+    static AStackString< 256 >  ms_ShowIncludesMarker;
+    static bool                 ms_ShowIncludesMarkerDetected;
+    static Mutex                ms_ShowIncludesMarkerMutex;
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
…. This could result in fastbuild not rebuilding some dependencies when it should have,,, This affected pch dependencies and possibly any file compiled locally.

- Adding code for detecting the /showincludes marker for foreign languages. This code will work for all languages using single bytes chars.
- For clang-cl, make the include parser support both \r\n and \n line endings
- Also handle that /showIncludes with clang-cl doesn't print the filename on the first line