### PR TITLE
- Added support for multiple broker folders separated my semi-colon. …

### DIFF
--- a/Code/Core/Strings/AString.cpp
+++ b/Code/Core/Strings/AString.cpp
@@ -601,6 +601,35 @@ void AString::Trim( uint32_t startCharsToTrim, uint32_t endCharsToTrim )
     Assign( Get() + startCharsToTrim, GetEnd() - endCharsToTrim );
 }
 
+// TrimStart: Remove all occurences of charToTrimFromStart from the start of the string
+//------------------------------------------------------------------------------
+void AString::TrimStart( char charToTrimFromStart )
+{
+    uint32_t nbrCharsToRemoveFromStart = 0;
+    const char * pos = m_Contents;
+    const char * end = m_Contents + m_Length;
+    for ( ; pos < end && *pos == charToTrimFromStart; ++pos, ++nbrCharsToRemoveFromStart ) 
+    {
+    }
+
+    Trim( nbrCharsToRemoveFromStart, 0 );
+}
+
+// TrimEnd : Remove all occurences of charToTrimFromEnd from the end of the string
+//------------------------------------------------------------------------------
+void AString::TrimEnd( char charToTrimFromEnd )
+{
+    uint32_t nbrCharsToRemoveFromEnd = 0;
+    const char * pos = m_Contents + m_Length - 1;
+    const char * end = m_Contents;
+    for ( ; pos >= end && *pos == charToTrimFromEnd; --pos, ++nbrCharsToRemoveFromEnd ) 
+    {
+    }
+
+    Trim( 0, nbrCharsToRemoveFromEnd );
+}
+
+
 // Replace ( char *, char * )
 //------------------------------------------------------------------------------
 uint32_t AString::Replace( const char * from, const char * to, uint32_t maxReplaces )

--- a/Code/Core/Strings/AString.h
+++ b/Code/Core/Strings/AString.h
@@ -96,6 +96,8 @@ public:
 
     // Trimming
     void Trim( uint32_t startCharsToTrim, uint32_t endCharsToTrim );
+    void TrimStart( char charToTrimFromStart );
+    void TrimEnd( char charToTrimFromStart );
 
     // searching
     const char *    Find( char c, const char * startPos = nullptr, const char * endPos = nullptr ) const;

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -385,7 +385,7 @@ bool FBuild::Build( Node * nodeToBuild )
         }
         else
         {
-            OUTPUT( "Distributed Compilation : %u Workers in pool '%s'\n", (uint32_t)workers.GetSize(), m_WorkerBrokerage.GetBrokerageRoot().Get() );
+            OUTPUT( "Distributed Compilation : %u Workers in pool '%s'\n", (uint32_t)workers.GetSize(), m_WorkerBrokerage.GetBrokerageRootsPaths().Get() );
             m_Client = FNEW( Client( workers, m_Options.m_DistributionPort, settings->GetWorkerConnectionLimit(), m_Options.m_DistVerbose ) );
         }
     }

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerage.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerage.cpp
@@ -44,23 +44,53 @@ void WorkerBrokerage::Init()
     uint32_t protocolVersion = Protocol::PROTOCOL_VERSION;
 
     // root folder
-    AStackString<> root;
-    if ( Env::GetEnvVariable( "FASTBUILD_BROKERAGE_PATH", root ) )
+    AStackString<> brokeragePath;
+    if ( Env::GetEnvVariable( "FASTBUILD_BROKERAGE_PATH", brokeragePath) )
     {
-        // <path>/<group>/<version>/
-        #if defined( __WINDOWS__ )
-            m_BrokerageRoot.Format( "%s\\main\\%u.windows\\", root.Get(), protocolVersion );
-        #elif defined( __OSX__ )
-            m_BrokerageRoot.Format( "%s/main/%u.osx/", root.Get(), protocolVersion );
-        #else
-            m_BrokerageRoot.Format( "%s/main/%u.linux/", root.Get(), protocolVersion );
-        #endif
+        // FASTBUILD_BROKERAGE_PATH can contain multiple paths separated by semi-colon. The worker will register itself into the first path only but
+        // the additional paths are paths to additional broker roots allowed for finding remote workers(in order of priority)
+        const char* start = brokeragePath.Get();
+        const char* end = brokeragePath.GetEnd();
+        AStackString<> pathSeparator( ";" );
+        while ( true )
+        {
+            AStackString<> root;
+            AStackString<> brokerageRoot;
+
+            const char* separator = brokeragePath.Find( pathSeparator, start, end );
+            if ( separator != nullptr )
+                root.Append( start, separator - start );
+            else
+                root.Append( start, end - start );
+            root.TrimStart(' ');
+            root.TrimEnd(' ');
+            // <path>/<group>/<version>/
+            #if defined( __WINDOWS__ )
+                brokerageRoot.Format( "%s\\main\\%u.windows\\", root.Get(), protocolVersion );
+            #elif defined( __OSX__ )
+                brokerageRoot.Format( "%s/main/%u.osx/", root.Get(), protocolVersion );
+            #else
+                brokerageRoot.Format( "%s/main/%u.linux/", root.Get(), protocolVersion );
+            #endif
+
+            m_BrokerageRoots.Append( brokerageRoot );
+            if ( !m_BrokerageRootsPaths.IsEmpty() )
+                m_BrokerageRootsPaths.Append( pathSeparator );
+
+            m_BrokerageRootsPaths.Append( brokerageRoot );
+
+            if ( separator != nullptr )
+                start = separator + 1;
+            else
+                break;
+        }
     }
 
     Network::GetHostName(m_HostName);
 
     AStackString<> filePath;
-    m_BrokerageFilePath.Format( "%s%s", m_BrokerageRoot.Get(), m_HostName.Get() );
+    if ( !m_BrokerageRoots.IsEmpty() )
+        m_BrokerageFilePath.Format( "%s%s", m_BrokerageRoots[0].Get(), m_HostName.Get() );
     m_TimerLastUpdate.Start();
 
     m_Initialized = true;
@@ -85,20 +115,27 @@ void WorkerBrokerage::FindWorkers( Array< AString > & workerList )
 
     Init();
 
-    if ( m_BrokerageRoot.IsEmpty() )
+    if ( m_BrokerageRoots.IsEmpty() )
     {
         FLOG_WARN( "No brokerage root; did you set FASTBUILD_BROKERAGE_PATH?" );
         return;
     }
 
     Array< AString > results( 256, true );
-    if ( !FileIO::GetFiles( m_BrokerageRoot,
-                            AStackString<>( "*" ),
-                            false,
-                            &results ) )
+    for( AString& root : m_BrokerageRoots )
     {
-        FLOG_WARN( "No workers found in '%s'", m_BrokerageRoot.Get() );
-        return; // no files found
+        size_t filesBeforeSearch = results.GetSize();
+        if ( !FileIO::GetFiles(root,
+                                AStackString<>( "*" ),
+                                false,
+                                &results ) )
+        {
+            FLOG_WARN( "No workers found in '%s'", root.Get() );
+        }
+        else
+        {
+            FLOG_WARN( "%zu workers found in '%s'", results.GetSize() - filesBeforeSearch, root.Get() );
+        }
     }
 
     // presize
@@ -128,7 +165,7 @@ void WorkerBrokerage::SetAvailability(bool available)
     Init();
 
     // ignore if brokerage not configured
-    if ( m_BrokerageRoot.IsEmpty() )
+    if ( m_BrokerageRoots.IsEmpty() )
     {
         return;
     }
@@ -144,7 +181,7 @@ void WorkerBrokerage::SetAvailability(bool available)
             //
             if ( !FileIO::FileExists( m_BrokerageFilePath.Get() ) )
             {
-                FileIO::EnsurePathExists( m_BrokerageRoot );
+                FileIO::EnsurePathExists( m_BrokerageRoots[0] );
 
                 // create file to signify availability
                 FileStream fs;

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerage.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerage.h
@@ -18,7 +18,8 @@ public:
     WorkerBrokerage();
     ~WorkerBrokerage();
 
-    inline const AString & GetBrokerageRoot() const { return m_BrokerageRoot; }
+    inline const Array<AString> & GetBrokerageRoots() const { return m_BrokerageRoots; }
+    inline const AString & GetBrokerageRootsPaths() const { return m_BrokerageRootsPaths; }
 
     // client interface
     void FindWorkers( Array< AString > & workerList );
@@ -28,7 +29,8 @@ public:
 private:
     void Init();
 
-    AString             m_BrokerageRoot;
+    Array<AString>      m_BrokerageRoots;
+    AString             m_BrokerageRootsPaths;
     bool                m_Availability;
     bool                m_Initialized;
     AString             m_HostName;


### PR DESCRIPTION
…Fastbuild worker only registers in the first specified folder but we are allowed to find workers in all specified folders in order of priority.

Example:
Machines in studio A would have their broker setup like this:
FASTBUILD_BROKERAGE_PATH=\server\fastbuild\studios\A
While machines in studio B:
FASTBUILD_BROKERAGE_PATH=\server\fastbuild\studios\B;\server\fastbuild\studios\A

In this case, machines in both studio get registered in their respective studio folder, but machines in studio B could also build using machines from studio A.

Since studio A have a lot of machine there is no point in using machines from studio B. That will also decrease the bandwidth used between the two studios and improve a bit latency for users in studio A as they won't try to build in studio B. For studio B user, well, it is better to add a little bit of latency than trying to build with only a few workers.